### PR TITLE
Fix stale apt repo issue with code coverage github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,8 @@ jobs:
         steps:
             - name: Checkout repository
               uses: actions/checkout@v2
+            - name: Update apt
+              run: sudo apt-get update
             - name: Install dependencies for build and coverage
               run: sudo apt-get install libudev-dev libcec4
             - name: Install stable toolchain


### PR DESCRIPTION
Signed-off-by: Sami Salonen <ssalonen@gmail.com>

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/ssalonen/cec-rs/blob/master/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/ssalonen/cec-rs/blob/master/CHANGELOG.md
-->
