### PR TITLE
Added log_message_callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+<<<<<<< HEAD
 - Fixes build errors with libcec-sys
 - Added `log_message_callbacks`.
+=======
+-   Added `log_message_callbacks`.
+>>>>>>> bc8a622 (Updated changelog)
 
 ## 2.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- N/A
+-   Added `log_message_callbacks`.
 
 ## 2.2.1
 
-- CI fixes and improvements
-- Fix clippy errors, regenerating `enums.rs` and utilizing new `enum-repr-derive`
-- Avoid unsafe transmute with `c_char`
+-   CI fixes and improvements
+-   Fix clippy errors, regenerating `enums.rs` and utilizing new `enum-repr-derive`
+-   Avoid unsafe transmute with `c_char`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Fixes build errors with libcec-sys
+- Added `log_message_callbacks`.
 
 ## 2.2.1
 
-- CI fixes and improvements
-- Fix clippy errors, regenerating `enums.rs` and utilizing new `enum-repr-derive`
-- Avoid unsafe transmute with `c_char`
+-   CI fixes and improvements
+-   Fix clippy errors, regenerating `enums.rs` and utilizing new `enum-repr-derive`
+-   Avoid unsafe transmute with `c_char`

--- a/examples/cec-example-cli/bin.rs
+++ b/examples/cec-example-cli/bin.rs
@@ -3,7 +3,10 @@ use env_logger;
 use log::trace;
 
 extern crate cec_rs;
-use cec_rs::{CecCommand, CecConnectionCfgBuilder, CecDeviceType, CecDeviceTypeVec, CecKeypress};
+use cec_rs::{
+    CecCommand, CecConnectionCfgBuilder, CecDeviceType, CecDeviceTypeVec, CecKeypress,
+    CecLogMessage,
+};
 use std::{thread, time};
 
 fn on_key_press(keypress: CecKeypress) {
@@ -23,6 +26,15 @@ fn on_command_received(command: CecCommand) {
     );
 }
 
+fn on_log_level(log_message: CecLogMessage) {
+    trace!(
+        "logMessageRecieved:  time: {}, level: {}, message: {}",
+        log_message.time,
+        log_message.level,
+        log_message.message
+    );
+}
+
 pub fn main() {
     env_logger::init();
 
@@ -31,6 +43,7 @@ pub fn main() {
         .device_name("Hifiberry".into())
         .key_press_callback(Box::new(on_key_press))
         .command_received_callback(Box::new(on_command_received))
+        .log_message_callback(Box::new(on_log_level))
         .device_types(CecDeviceTypeVec::new(CecDeviceType::AudioSystem))
         .build()
         .unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -411,17 +411,18 @@ mod command_tests {
 pub enum TryFromCecLogMessageError {
     MessageParseError,
     LogLevelParseError,
+    TimestampParseError,
     UnknownLogLevel,
 }
 
 #[derive(Clone)]
 pub struct CecLogMessage {
-    #[doc = "< the actual message, valid until returning from the log callback"]
+    #[doc = "the actual message"]
     pub message: String,
-    #[doc = "< log level of the message"]
+    #[doc = "log level of the message"]
     pub level: CecLogLevel,
-    #[doc = "< the timestamp of this message"]
-    pub time: i64,
+    #[doc = "duration since connection was established"]
+    pub time: Duration,
 }
 
 impl core::convert::TryFrom<cec_log_message> for CecLogMessage {
@@ -435,11 +436,15 @@ impl core::convert::TryFrom<cec_log_message> for CecLogMessage {
             .to_owned();
         let level = CecLogLevel::try_from(log_message.level)
             .map_err(|_| TryFromCecLogMessageError::LogLevelParseError)?;
+        let time = log_message
+            .time
+            .try_into()
+            .map_err(|_| TryFromCecLogMessageError::TimestampParseError)?;
 
         Ok(CecLogMessage {
             message,
             level,
-            time: log_message.time,
+            time: Duration::from_millis(time),
         })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -437,8 +437,8 @@ impl core::convert::TryFrom<cec_log_message> for CecLogMessage {
             .map_err(|_| TryFromCecLogMessageError::LogLevelParseError)?;
 
         Ok(CecLogMessage {
-            message: message,
-            level: level,
+            message,
+            level,
             time: log_message.time,
         })
     }


### PR DESCRIPTION
I added support for the `log_message_callback` in order to easier write code for applications that monitor the feed rather than acts as a remote.

I tried to keep it relatively similar to what was already in the repo (great Rust btw, learned some new tricks from this repo). I did run the tests, ran clippy and rustfmt. Hope it's decent enough.

Sidenote: Thanks a lot for taking the time to write this wrapper in Rust, very much appreciate it.