### PR TITLE
Fix return type of get_device_power_status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `get_device_power_status` returns `CecPowerStatus` instead of `CecConnectionResult<()>`
+
 ## [6.0.0]
 
 - libcec-sys updated to v4.0.0, bringing Windows support and vendored libcec updated to v6


### PR DESCRIPTION
<!-- Please explain the changes you made -->
`get_device_power_status` should return `CecPowerStatus`, but it was returning `CecConnectionResult<()>`, which didn't make much sense.

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/ssalonen/cec-rs/blob/master/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/ssalonen/cec-rs/blob/master/CHANGELOG.md
-->
