### PR TITLE
Add get_logical_addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add `get_logical_addresses()`
+
 ## [7.0.0]
 
 - `get_device_power_status` returns `CecPowerStatus` instead of `CecConnectionResult<()>`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -580,7 +580,6 @@ pub enum TryFromCecLogicalAddressesError {
 impl TryFrom<cec_logical_addresses> for CecLogicalAddresses {
     type Error = TryFromCecLogicalAddressesError;
     fn try_from(addresses: cec_logical_addresses) -> Result<Self, Self::Error> {
-
         let primary = CecLogicalAddress::try_from(addresses.primary)
             .map_err(|_| TryFromCecLogicalAddressesError::InvalidPrimaryAddress)?;
         let primary = KnownCecLogicalAddress::new(primary)


### PR DESCRIPTION
This adds a wrapper for `libcec_get_logical_addresses()`.

This is necessary to allow a device to know its own identity. The alternative is to hard code a logical address, and hope that it hasn't been reassigned to other CEC devices... which isn't reliable when you have more than one HDMI device of the same type.

Other API additions:

* make `CecLogicalAddresses` fields public, so they can be read
* add `cec_logical_addresses` -> `CecLogicalAddresses` translation

Tested with a P8 USB adapter running on macOS, where my code is acting as a Recorder device, and there's another Recorder device also attached to another HDMI port on my TV.