### PR TITLE
Fix calling `libcec_close` twice on drop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fix calling `libcec_close` twice on drop
+
 ## 7.1.1
 
 - Require libcec >= 4.0.3 for fixed windows compatibility

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,13 +28,13 @@ use libcec_sys::{
     cec_command, cec_datapacket, cec_device_type_list, cec_keypress, cec_log_message,
     cec_logical_address, cec_logical_addresses, cec_power_status, libcec_audio_get_status,
     libcec_audio_mute, libcec_audio_toggle_mute, libcec_audio_unmute, libcec_clear_configuration,
-    libcec_close, libcec_configuration, libcec_connection_t, libcec_destroy,
-    libcec_get_active_source, libcec_get_device_power_status, libcec_get_logical_addresses,
-    libcec_initialise, libcec_is_active_source, libcec_mute_audio, libcec_open,
-    libcec_power_on_devices, libcec_send_key_release, libcec_send_keypress,
-    libcec_set_active_source, libcec_set_inactive_view, libcec_set_logical_address,
-    libcec_standby_devices, libcec_switch_monitoring, libcec_transmit, libcec_volume_down,
-    libcec_volume_up, ICECCallbacks, LIBCEC_OSD_NAME_SIZE, LIBCEC_VERSION_CURRENT,
+    libcec_configuration, libcec_connection_t, libcec_destroy, libcec_get_active_source,
+    libcec_get_device_power_status, libcec_get_logical_addresses, libcec_initialise,
+    libcec_is_active_source, libcec_mute_audio, libcec_open, libcec_power_on_devices,
+    libcec_send_key_release, libcec_send_keypress, libcec_set_active_source,
+    libcec_set_inactive_view, libcec_set_logical_address, libcec_standby_devices,
+    libcec_switch_monitoring, libcec_transmit, libcec_volume_down, libcec_volume_up, ICECCallbacks,
+    LIBCEC_OSD_NAME_SIZE, LIBCEC_VERSION_CURRENT,
 };
 
 use num_traits::ToPrimitive;
@@ -1347,7 +1347,6 @@ impl CecConnectionCfg {
 impl Drop for CecConnection {
     fn drop(&mut self) {
         unsafe {
-            libcec_close(self.1);
             libcec_destroy(self.1);
         }
     }


### PR DESCRIPTION
The `libcec_close` call in `CecConnection::drop` is unnecessary because `libcec_destroy` already calls `libcec_close`: https://github.com/Pulse-Eight/libcec/blob/libcec-6.0.2/src/libcec/LibCECC.cpp#L53-L61

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/ssalonen/cec-rs/blob/master/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/ssalonen/cec-rs/blob/master/CHANGELOG.md
-->
