### PR TITLE
Fix `is_active_source` result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fix `is_active_source` result
+
 ## 7.1.1
 
 - Require libcec >= 4.0.3 for fixed windows compatibility

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1119,12 +1119,8 @@ impl CecConnection {
         }
     }
 
-    pub fn is_active_source(&self, address: CecLogicalAddress) -> CecConnectionResult<()> {
-        if unsafe { libcec_is_active_source(self.1, address.into()) } == 0 {
-            Err(CecConnectionResultError::TransmitFailed)
-        } else {
-            Ok(())
-        }
+    pub fn is_active_source(&self, address: CecLogicalAddress) -> bool {
+        (unsafe { libcec_is_active_source(self.1, address.into()) }) != 0
     }
 
     pub fn get_device_power_status(&self, address: CecLogicalAddress) -> CecPowerStatus {


### PR DESCRIPTION
`is_active_source` returns a boolean, and doesn't internally transmit anything:
- https://github.com/Pulse-Eight/libcec/blob/libcec-6.0.2/src/libcec/LibCECC.cpp#L271-L277
- https://github.com/Pulse-Eight/libcec/blob/libcec-6.0.2/src/libcec/LibCEC.cpp#L342-L345
- https://github.com/Pulse-Eight/libcec/blob/libcec-6.0.2/src/libcec/CECClient.cpp#L1484-L1487
- https://github.com/Pulse-Eight/libcec/blob/libcec-6.0.2/src/libcec/CECProcessor.cpp#L451-L455
- https://github.com/Pulse-Eight/libcec/blob/libcec-6.0.2/src/libcec/devices/CECBusDevice.h#L178

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/ssalonen/cec-rs/blob/master/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/ssalonen/cec-rs/blob/master/CHANGELOG.md
-->
