### PR TITLE
Add adapter auto detection for unspecified port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add adapter auto detection for unspecified port
+
 ## 7.1.1
 
 - Require libcec >= 4.0.3 for fixed windows compatibility

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ use libcec_sys::{
 use num_traits::ToPrimitive;
 use std::convert::{TryFrom, TryInto};
 use std::ffi::{CStr, CString};
+use std::mem::MaybeUninit;
 use std::os::raw::c_void;
 use std::time::Duration;
 use std::{mem, result};
@@ -969,7 +970,9 @@ pub struct CecConnectionCfg {
     #[builder(default, setter(strip_option), pattern = "owned")]
     pub log_message_callback: Option<Box<FnLogMessage>>,
 
-    pub port: String,
+    #[doc = "< the COM port to connect to. leave this untouched to autodetect"]
+    #[builder(default, setter(strip_option))]
+    pub port: Option<String>,
 
     #[builder(default = "Duration::from_secs(5)")]
     pub open_timeout: Duration,
@@ -1305,8 +1308,6 @@ impl CecConnectionCfg {
             log_message_callbacks: self.log_message_callback.take(),
         });
         let rust_callbacks_as_void_ptr = &*pinned_callbacks as *const _ as *mut _;
-        let port = CString::new(self.port.clone()).expect("Invalid port name");
-        let open_timeout = self.open_timeout.as_millis() as u32;
         let connection = CecConnection(
             self,
             unsafe { libcec_initialise(&mut cfg) },
@@ -1316,9 +1317,36 @@ impl CecConnectionCfg {
             return Err(CecConnectionResultError::LibInitFailed);
         }
 
-        if unsafe { libcec_open(connection.1, port.as_ptr(), open_timeout) } == 0 {
-            return Err(CecConnectionResultError::AdapterOpenFailed);
-        }
+        let open_timeout = connection.0.open_timeout.as_millis() as u32;
+        match &connection.0.port {
+            Some(port) => {
+                let port = CString::new(port.as_str()).expect("Invalid port name");
+                if unsafe { libcec_open(connection.1, port.as_ptr(), open_timeout) } == 0 {
+                    return Err(CecConnectionResultError::AdapterOpenFailed);
+                }
+            }
+            None => {
+                let mut adapters = MaybeUninit::<[libcec_sys::cec_adapter_descriptor; 1]>::uninit();
+                let num_adapters = unsafe {
+                    libcec_sys::libcec_detect_adapters(
+                        connection.1,
+                        adapters.as_mut_ptr() as *mut _,
+                        1,
+                        std::ptr::null(),
+                        true as i32,
+                    )
+                };
+
+                if num_adapters == 0 {
+                    return Err(CecConnectionResultError::NoAdapterFound);
+                }
+
+                let port = unsafe { adapters.assume_init() }[0].strComName;
+                if unsafe { libcec_open(connection.1, port.as_ptr(), open_timeout) == 0 } {
+                    return Err(CecConnectionResultError::AdapterOpenFailed);
+                }
+            }
+        };
 
         #[cfg(abi4)]
         let callback_ret = unsafe {


### PR DESCRIPTION
With this PR, now if you leave off the port in the configuration, the first adapter will be selected automatically. Like in [cec-client](https://github.com/Pulse-Eight/libcec/blob/libcec-6.0.2/src/cec-client/cec-client.cpp#L1330-L1347).

Based off the work @opeik started for #45 and closes #45.

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/ssalonen/cec-rs/blob/master/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/ssalonen/cec-rs/blob/master/CHANGELOG.md
-->
