### PR TITLE
Use CString for port

### DIFF
--- a/examples/cec-example-cli/bin.rs
+++ b/examples/cec-example-cli/bin.rs
@@ -39,7 +39,7 @@ pub fn main() {
     env_logger::init();
 
     let cfg = CecConnectionCfgBuilder::default()
-        .port("RPI".into())
+        .port(c"RPI".into())
         .device_name("Hifiberry".into())
         .key_press_callback(Box::new(on_key_press))
         .command_received_callback(Box::new(on_command_received))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1092,7 +1092,7 @@ pub struct CecConnectionCfg {
 
     #[doc = "< the COM port to connect to. leave this untouched to autodetect"]
     #[builder(default, setter(strip_option))]
-    pub port: Option<String>,
+    pub port: Option<CString>,
 
     #[builder(default = "Duration::from_secs(5)")]
     pub open_timeout: Duration,
@@ -1407,10 +1407,6 @@ impl CecConnectionCfg {
     /// - LibInitFailed: libcec_sys::libcec_initialise fails
     /// - AdapterOpenFailed: libcec_sys::libcec_open fails
     /// - CallbackRegistrationFailed: libcec_sys::libcec_enable_callbacks fails
-    ///
-    /// # Panics
-    ///
-    /// Panics if self.port contains internal 0 byte
     pub fn open(mut self) -> CecConnectionResult<CecConnection> {
         let mut cfg: libcec_configuration = (&self).into();
         // Consume self.*_callback and build CecCallbacks from those
@@ -1432,7 +1428,6 @@ impl CecConnectionCfg {
         let open_timeout = connection.0.open_timeout.as_millis() as u32;
         match &connection.0.port {
             Some(port) => {
-                let port = CString::new(port.as_str()).expect("Invalid port name");
                 if unsafe { libcec_open(connection.1, port.as_ptr(), open_timeout) } == 0 {
                     return Err(CecConnectionResultError::AdapterOpenFailed);
                 }


### PR DESCRIPTION
This shifts a potential panic outside of the library, and avoids the unnecessary overhead of UTF-8 validation when a port is dynamically received (eg. through walking the file-system / udev hotplug events).

It should also fix connecting to a device with a path that isn't valid UTF-8, but I don't think that'd ever happen in practice.

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/ssalonen/cec-rs/blob/master/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/ssalonen/cec-rs/blob/master/CHANGELOG.md
-->
