### PR TITLE
Implement Send & Sync for CecConnection

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1492,6 +1492,16 @@ impl Drop for CecConnection {
     }
 }
 
+// libcec doesn't use thread local storage, so it's safe to send
+// CecConnection across threads.
+unsafe impl Send for CecConnection {}
+
+// libcec guards interior mutability behind mutex locks. It's hard to
+// verify that their implementation is perfectly thread safe, but they
+// wouldn't be using mutexes if they weren't aiming for thread safety,
+// so we trust that their implementation is correct.
+unsafe impl Sync for CecConnection {}
+
 impl From<&CecConnectionCfg> for libcec_configuration {
     fn from(config: &CecConnectionCfg) -> libcec_configuration {
         let mut cfg: libcec_configuration;


### PR DESCRIPTION
libcec doesn't use thread local storage, so I think it should safe to send CecConnection across threads.

libcec also guards interior mutability behind mutex locks. It's hard to verify that their implementation is perfectly thread safe, but they wouldn't be using mutexes if they weren't aiming for thread safety, so I think it's safe to assume it's correct.

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/ssalonen/cec-rs/blob/master/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/ssalonen/cec-rs/blob/master/CHANGELOG.md
-->
